### PR TITLE
Use ES6 class syntax in rncc snippet

### DIFF
--- a/snippets/createClass_react_native.sublime-snippet
+++ b/snippets/createClass_react_native.sublime-snippet
@@ -10,14 +10,13 @@ var {
   View,
 } = React;
 
-var ${1:Component} = React.createClass({
-  render: function() {
+class ${1:Component} extends React.Component {
+  render() {
     return (
       <View />
     );
   }
-});
-
+}
 
 var styles = StyleSheet.create({
 


### PR DESCRIPTION
Use ES6 class syntax in the "Create react-native Class" snippet.
